### PR TITLE
Bugfix/naming consistency

### DIFF
--- a/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
+++ b/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
@@ -79,7 +79,7 @@ constructor(
                 feedback.linkingEntityDataKey)
 
 
-        // add feedbacks
+        // add feedback
         val linkingEntitiesList = feedback.link.toList()
         val nonLinkingEntitiesList = feedback.unlink.toList()
 
@@ -101,7 +101,7 @@ constructor(
         dataManager.markAsNeedsToBeLinked(feedback.link + feedback.unlink)
 
 
-        logger.info("Submitted $positiveFeedbackCount positive and $negativeFeedbackCount negative feedbacks for " +
+        logger.info("Submitted $positiveFeedbackCount positive and $negativeFeedbackCount negative feedback for " +
                 "linking id ${feedback.linkingEntityDataKey.entityKeyId}")
 
         return positiveFeedbackCount + negativeFeedbackCount

--- a/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
+++ b/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
@@ -144,7 +144,7 @@ constructor(
     }
 
     @PostMapping(path = [LinkingFeedbackApi.ENTITY], produces = [MediaType.APPLICATION_JSON_VALUE])
-    override fun getLinkingFeedbacksOnEntity(
+    override fun getLinkingFeedbackOnEntity(
             @RequestParam(value = LinkingFeedbackApi.FEEDBACK_TYPE, required = false) feedbackType: FeedbackType,
             @RequestBody entity: EntityDataKey): Iterable<EntityLinkingFeedback> {
         return feedbackService.getLinkingFeedbackOnEntity(feedbackType, entity)
@@ -175,7 +175,7 @@ constructor(
     @GetMapping(
             path = [LinkingFeedbackApi.FEATURES + LinkingFeedbackApi.ALL],
             produces = [MediaType.APPLICATION_JSON_VALUE])
-    override fun getAllLinkingFeedbacksWithFeatures(): Iterable<EntityLinkingFeatures> {
+    override fun getAllLinkingFeedbackWithFeatures(): Iterable<EntityLinkingFeatures> {
         return feedbackService.getLinkingFeedbacks().map {
             val entities = dataLoader.getEntities(setOf(it.entityPair.first, it.entityPair.second))
             EntityLinkingFeatures(

--- a/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
+++ b/src/main/kotlin/com/openlattice/linking/controllers/LinkingFeedbackController.kt
@@ -168,7 +168,7 @@ constructor(
     }
 
     @GetMapping(path = [LinkingFeedbackApi.ALL], produces = [MediaType.APPLICATION_JSON_VALUE])
-    override fun getAllLinkingFeedbacks(): Iterable<EntityLinkingFeedback> {
+    override fun getAllLinkingFeedback(): Iterable<EntityLinkingFeedback> {
         return feedbackService.getLinkingFeedbacks()
     }
 


### PR DESCRIPTION
Found this a bit a weird function name with `feedbacks` when returning an iterable and `feedback` when it's singular. It's grammatically incorrect.

Just a suggestion while translating to api-clients, feel free to discard :) 