### PR TITLE
filter linking entity sets from being linked, fix warnings

### DIFF
--- a/src/main/java/com/openlattice/linking/pods/LinkerPostConfigurationServicesPod.java
+++ b/src/main/java/com/openlattice/linking/pods/LinkerPostConfigurationServicesPod.java
@@ -170,7 +170,6 @@ public class LinkerPostConfigurationServicesPod {
     public BackgroundLinkingService linkingService() throws IOException {
         return new BackgroundLinkingService( executor,
                 hazelcastInstance,
-                pgEdmManager,
                 blocker(),
                 matcher,
                 idService(),


### PR DESCRIPTION
A quick fix for filtering linking entity sets from being linked. Since they have no real entities, it wouldn't do any harm, but every time it checked, if the entity set had entities to link or not against the ids table.