### PR TITLE
re-introduce whitelist as priority list

### DIFF
--- a/src/main/java/com/openlattice/linking/pods/LinkerPostConfigurationServicesPod.java
+++ b/src/main/java/com/openlattice/linking/pods/LinkerPostConfigurationServicesPod.java
@@ -56,8 +56,6 @@ import com.openlattice.linking.blocking.ElasticsearchBlocker;
 import com.openlattice.linking.controllers.RealtimeLinkingController;
 import com.openlattice.linking.graph.PostgresLinkingQueryService;
 import com.zaxxer.hikari.HikariDataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -68,7 +66,6 @@ import java.io.IOException;
 @Configuration
 @Import( { ByteBlobServicePod.class } )
 public class LinkerPostConfigurationServicesPod {
-    private static final Logger            logger = LoggerFactory.getLogger( LinkerPostConfigurationServicesPod.class );
 
     @Inject
     private HazelcastInstance hazelcastInstance;

--- a/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
+++ b/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
@@ -79,7 +79,7 @@ class BackgroundLinkingService(
             while (true) {
                 val priority = entitySets.values( Predicate<UUID, EntitySet> {
                     mapEntry -> priorityEntitySets.contains(mapEntry.key)
-                })
+                }).asSequence()
 
                 //TODO: Switch to unlimited entity sets
                 (priority +

--- a/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
+++ b/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
@@ -25,8 +25,11 @@ import com.google.common.base.Stopwatch
 import com.google.common.collect.Sets
 import com.google.common.util.concurrent.ListeningExecutorService
 import com.hazelcast.core.HazelcastInstance
+import com.hazelcast.query.Predicate
+import com.hazelcast.query.Predicates
 import com.openlattice.data.EntityDataKey
 import com.openlattice.data.EntityKeyIdService
+import com.openlattice.edm.EntitySet
 import com.openlattice.edm.set.EntitySetFlag
 import com.openlattice.hazelcast.HazelcastMap
 import com.openlattice.hazelcast.HazelcastQueue
@@ -74,7 +77,9 @@ class BackgroundLinkingService(
     private val enqueuer = executor.submit {
         try {
             while (true) {
-                val priority = entitySets.getAll(priorityEntitySets).values.asSequence()
+                val priority = entitySets.values( Predicate<UUID, EntitySet> {
+                    mapEntry -> priorityEntitySets.contains(mapEntry.key)
+                })
 
                 //TODO: Switch to unlimited entity sets
                 (priority +

--- a/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
+++ b/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
@@ -77,9 +77,7 @@ class BackgroundLinkingService(
     private val enqueuer = executor.submit {
         try {
             while (true) {
-                val priority = entitySets.values( Predicate<UUID, EntitySet> {
-                    mapEntry -> priorityEntitySets.contains(mapEntry.key)
-                }).asSequence()
+                val priority = entitySets.getAll(priorityEntitySets).values.asSequence()
 
                 //TODO: Switch to unlimited entity sets
                 (priority +

--- a/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
+++ b/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
@@ -28,14 +28,13 @@ import com.hazelcast.core.HazelcastInstance
 import com.openlattice.data.EntityDataKey
 import com.openlattice.data.EntityKeyIdService
 import com.openlattice.edm.set.EntitySetFlag
-import com.openlattice.entryprocessors.GetFilteredEntitySetIdsForLinking
 import com.openlattice.hazelcast.HazelcastMap
 import com.openlattice.hazelcast.HazelcastQueue
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import java.sql.Connection
 import java.time.Instant
-import java.util.*
+import java.util.UUID
 import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit
 import kotlin.streams.asSequence
@@ -77,7 +76,7 @@ class BackgroundLinkingService(
         try {
             while (true) {
                 val entitySets = entitySets.values.toSet()
-                
+
                 val priority = entitySets.stream().filter {
                     priorityEntitySets.contains(it.id)
                 }.asSequence()

--- a/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
+++ b/src/main/kotlin/com/openlattice/linking/BackgroundLinkingService.kt
@@ -74,16 +74,16 @@ class BackgroundLinkingService(
     private val enqueuer = executor.submit {
         try {
             while (true) {
-                val priority = entitySets.values.asSequence().filter {
-                    priorityEntitySets.contains(it.id)
-                }
+                val priority = entitySets.getAll(priorityEntitySets).values.asSequence()
 
                 //TODO: Switch to unlimited entity sets
                 (priority +
                     entitySets.values
                         .asSequence()
                         .filter {
-                            linkableTypes.contains(it.entityTypeId) && !it.flags.contains(EntitySetFlag.LINKING)
+                            !priorityEntitySets.contains(it.id)
+                                    && linkableTypes.contains(it.entityTypeId)
+                                    && !it.flags.contains(EntitySetFlag.LINKING)
                         }).flatMap { es ->
                             logger.debug("Starting to queue linking candidates from entity set {}", es.id)
                             val forLinking = lqs.getEntitiesNeedingLinking(es.id, 2 * configuration.loadSize)


### PR DESCRIPTION
This PR:
- makes BackgroundLinkingService use the whitelist as a priority list to be added to the indexing queue before all other ids